### PR TITLE
Added BME680 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,7 @@
 framework = arduino
 monitor_speed = 115200
 extra_scripts = pre:extra_script.py
-lib_deps =
+lib_deps = 
 	links2004/WebSockets@^2.3.5
 	knolleary/PubSubClient@^2.8
 	bblanchon/ArduinoJson@^5.13.4
@@ -28,22 +28,21 @@ lib_deps =
 	TimeLib = https://github.com/PaulStoffregen/Time.git
 	marcmerlin/FastLED NeoMatrix@^1.2
 
-
 [env:wemos_d1_mini32]
 platform = espressif32
 board = wemos_d1_mini32
 framework = ${common.framework}
 board_build.f_cpu = 80000000L
 monitor_speed = ${common.monitor_speed}
-extra_scripts= ${common.extra_scripts}
-platform_packages =
+extra_scripts = ${common.extra_scripts}
+platform_packages = 
 	framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0-alpha1
-	toolchain-xtensa32@~2.80400.0  
+	toolchain-xtensa32@~2.80400.0
 lib_deps = 
 	${common.lib_deps}
 	WiFiManager = https://github.com/tzapu/WiFiManager.git#esp32s2
 	plerup/EspSoftwareSerial@^6.11.4
-	
+	adafruit/Adafruit BME680 Library@^2.0.1
 
 [env:ESP8266]
 platform = espressif8266@2.6.3
@@ -51,11 +50,11 @@ board = nodemcu
 framework = ${common.framework}
 board_build.filesystem = littlefs
 monitor_speed = ${common.monitor_speed}
-extra_scripts= ${common.extra_scripts}
+extra_scripts = ${common.extra_scripts}
 lib_deps = 
 	${common.lib_deps}
 	tzapu/WiFiManager@^0.16.0
-
+	adafruit/Adafruit BME680 Library@^2.0.1
 
 [env:d1_mini]
 platform = espressif8266@2.6.3
@@ -63,7 +62,8 @@ board = d1_mini
 framework = ${common.framework}
 board_build.filesystem = littlefs
 monitor_speed = ${common.monitor_speed}
-extra_scripts= ${common.extra_scripts}
+extra_scripts = ${common.extra_scripts}
 lib_deps = 
 	${common.lib_deps}
 	tzapu/WiFiManager@^0.16.0
+	adafruit/Adafruit BME680 Library@^2.0.1

--- a/webui/src/store/index.js
+++ b/webui/src/store/index.js
@@ -215,6 +215,9 @@ function getDisplayName(key) {
       case "humidity":
           key = "Humidity";
           break;
+      case "gas":
+          key = "Gas";
+          break;
       case "pressure":
           key = "Pressure";
           break;
@@ -303,6 +306,11 @@ function getDisplayValue(key, value) {
       case "pressure":
           if (typeof value == "number") {
               value = Math.round(value) + " hPa";
+          }
+          break;
+      case "gas":
+          if (typeof value == "number") {
+              value = Math.round(value) + " kOhm";
           }
           break;
   }


### PR DESCRIPTION
Added support libraries for Adafruit BME680. Included Gas values (in kOhm) to sensor readings.
Tried to extend the index.js file for WebInterface, however, seems the other .js files need some work as well.