### PR TITLE
Sensor pins assignable; LDR options; bugfix

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -81,7 +81,7 @@ String DHTPin="Pin_D1";
 String BMESCLPin="Pin_D1";
 String BMESDAPin="Pin_D3";
 String ldrDevice="GL5516";
-unsigned long ldrPulldown=1000; // 10k pulldown-resistor
+unsigned long ldrPulldown=10000; // 10k pulldown-resistor
 
 #define NUMMATRIX (32 * 8)
 CRGB leds[NUMMATRIX];

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -66,27 +66,33 @@ const int MQTT_RECONNECT_INTERVAL = 5000;
 //#define MQTT_MAX_PACKET_SIZE 8000
 
 //// LDR Config
-#define LDR_RESISTOR 10000 // ohms
 #define LDR_PIN A0
-#define LDR_PHOTOCELL LightDependentResistor::GL5516
 
 //// GPIO Config
 #if defined(ESP8266)
 #define MATRIX_PIN D2
-#define I2C_SDA D3
-#define I2C_SCL D1
-#define DHT_PIN D1
 #elif defined(ESP32)
 #define MATRIX_PIN 27
-#define I2C_SDA D3
-#define I2C_SCL D1
-#define DHT_PIN D1
 #endif
+
+String dfpRXPin="Pin_D7";
+String dfpTXPin="Pin_D8";
+String DHTPin="Pin_D1";
+String BMESCLPin="Pin_D1";
+String BMESDAPin="Pin_D3";
+String ldrDevice="GL5516";
+unsigned long ldrPulldown=1000; // 10k pulldown-resistor
 
 #define NUMMATRIX (32 * 8)
 CRGB leds[NUMMATRIX];
 
-#define VERSION "0.3.15"
+#define VERSION "0.3.15pinconfig"
+
+#if defined(ESP8266)
+bool isESP8266 = true;
+#else
+bool isESP8266 = false;
+#endif
 
 #if defined(ESP32)
 TwoWire twowire(BME280_ADDRESS_ALTERNATE);
@@ -110,10 +116,10 @@ HTTPUpdateServer httpUpdater;
 #endif
 
 WebSocketsServer webSocket = WebSocketsServer(81);
-LightDependentResistor photocell(LDR_PIN, LDR_RESISTOR, LDR_PHOTOCELL, 10);
+LightDependentResistor* photocell;
 DHTesp dht;
 DFPlayerMini_Fast mp3Player;
-SoftwareSerial softSerial(D7, D8); // RX | TX
+SoftwareSerial* softSerial;
 
 // TempSensor
 enum TempSensor
@@ -249,6 +255,7 @@ void SaveConfig()
 		JsonObject &json = jsonBuffer.createObject();
 
 		json["version"] = VERSION;
+		json["isESP8266"] = isESP8266;
 		json["temperatureUnit"] = static_cast<int>(temperatureUnit);
 		json["matrixBrightnessAutomatic"] = matrixBrightnessAutomatic;
 		json["mbaDimMin"] = mbaDimMin;
@@ -288,6 +295,14 @@ void SaveConfig()
 		json["humidityOffset"] = humidityOffset;
 		json["pressureOffset"] = pressureOffset;
 		json["gasOffset"] = gasOffset;
+
+		json["dfpRXpin"] = dfpRXPin;
+		json["dfpTXpin"] = dfpTXPin;
+		json["DHTPin"] = DHTPin;
+		json["BMESCLPin"] = BMESCLPin;
+		json["BMESDAPin"] = BMESDAPin;
+		json["ldrDevice"] = ldrDevice;
+		json["ldrPulldown"] = ldrPulldown;
 
 #if defined(ESP8266)
 		File configFile = LittleFS.open("/config.json", "w");
@@ -522,6 +537,41 @@ void SetConfigVaribles(JsonObject &json)
 	if (json.containsKey("gasOffset"))
 	{
 		gasOffset = json["gasOffset"].as<float>();
+	}
+
+	if (json.containsKey("dfpRXpin"))
+	{
+		dfpRXPin = json["dfpRXpin"].as<char *>();
+	}
+
+	if (json.containsKey("dfpTXpin"))
+	{
+		dfpTXPin = json["dfpTXpin"].as<char *>();
+	}
+
+	if (json.containsKey("DHTPin"))
+	{
+		DHTPin = json["DHTPin"].as<char *>();
+	}
+	
+	if (json.containsKey("BMESCLPin"))
+	{
+		BMESCLPin = json["BMESCLPin"].as<char *>();
+	}
+	
+	if (json.containsKey("BMESDAPin"))
+	{
+		BMESDAPin = json["BMESDAPin"].as<char *>();
+	}
+
+	if (json.containsKey("ldrDevice"))
+	{
+		ldrDevice = json["ldrDevice"].as<char *>();
+	}
+
+	if (json.containsKey("ldrPulldown"))
+	{
+		ldrPulldown = json["ldrPulldown"].as<unsigned long>();
 	}
 }
 
@@ -828,6 +878,10 @@ void CreateFrames(JsonObject &json)
 		if (json["sound"]["volume"] != NULL && json["sound"]["volume"].is<int>())
 		{
 			mp3Player.volume(json["sound"]["volume"].as<int>());
+			
+			// Sometimes, mp3Player gets hickups. A brief delay helps - but might hinder scrolling.
+			// So, do it only if there are more commands to come.
+			if (json["sound"]["control"].asString()>"") delay(80);
 		}
 		// Play
 		if (json["sound"]["control"] == "play")
@@ -1909,6 +1963,34 @@ int *GetUserCutomCorrection()
 	return rgbArray;
 }
 
+LightDependentResistor::ePhotoCellKind TranslatePhotocell(String photocell)
+{
+	if (photocell=="GL5516") return LightDependentResistor::GL5516;
+	if (photocell=="GL5528") return LightDependentResistor::GL5528;
+	if (photocell=="GL5537_1") return LightDependentResistor::GL5537_1;
+	if (photocell=="GL5537_2") return LightDependentResistor::GL5537_2;
+	if (photocell=="GL5539") return LightDependentResistor::GL5539;
+	if (photocell=="GL5549") return LightDependentResistor::GL5549;
+	Log(F("Zuordnung LDR"), F("Unbekannter LDR-Typ"));
+	return LightDependentResistor::GL5528;
+}
+
+uint8_t TranslatePin(String pin)
+{
+	
+	if (pin=="Pin_D1") return D1;
+	if (pin=="Pin_D2") return D2;
+	if (pin=="Pin_D3") return D3;
+	if (pin=="Pin_D4") return D4;
+	if (pin=="Pin_D5") return D5;
+	if (pin=="Pin_D6") return D6;
+	if (pin=="Pin_D7") return D7;
+	if (pin=="Pin_D8") return D8;
+	if (pin=="Pin_27") return 27;
+	Log(F("Pin-Zuordnung"), F("Unbekannter Pin"));
+	return LED_BUILTIN;
+}
+
 void ClearTextArea()
 {
 	int16_t h = 8;
@@ -1990,7 +2072,7 @@ void setup()
 	}
 
 	// Temp Sensors
-	twowire.begin(I2C_SDA, I2C_SCL);
+	twowire.begin(TranslatePin(BMESDAPin), TranslatePin(BMESCLPin));
 	if (bme280.begin(BME280_ADDRESS_ALTERNATE, &twowire))
 	{
 		Log(F("Setup"), F("BME280 started"));
@@ -2009,7 +2091,7 @@ void setup()
 			delete bme680;
 			// AM2320 needs a delay to be reliably initialized
 			delay(600);
-			dht.setup(DHT_PIN, DHTesp::DHT22);
+			dht.setup(TranslatePin(DHTPin), DHTesp::DHT22);
 			if (!isnan(dht.getHumidity()) && !isnan(dht.getTemperature()))
 			{
 				Log(F("Setup"), F("DHT started"));
@@ -2039,7 +2121,8 @@ void setup()
 	}
 
 	// Init LightSensor
-	photocell.setPhotocellPositionOnGround(false);
+	photocell=new LightDependentResistor(LDR_PIN, ldrPulldown, TranslatePhotocell(ldrDevice), 10);
+	photocell->setPhotocellPositionOnGround(false);
 	ColorTemperature userColorTemp = GetUserColorTemp();
 	LEDColorCorrection userLEDCorrection = GetUserColorCorrection();
 
@@ -2133,10 +2216,12 @@ void setup()
 		Log(F("Setup"), F("MQTT started"));
 	}
 
-	softSerial.begin(9600);
+	softSerial=new SoftwareSerial(TranslatePin(dfpRXPin), TranslatePin(dfpTXPin)); 
+
+	softSerial->begin(9600);
 	Log(F("Setup"), F("Software Serial started"));
 
-	mp3Player.begin(softSerial);
+	mp3Player.begin(*softSerial);
 	Log(F("Setup"), F("DFPlayer started"));
 }
 
@@ -2231,7 +2316,7 @@ void loop()
 	{
 		sendLuxPrevMillis = millis();
 
-		currentLux = (roundf(photocell.getCurrentLux() * 1000) / 1000) + luxOffset;
+		currentLux = (roundf(photocell->getCurrentLux() * 1000) / 1000) + luxOffset;
 
 		SendLDR(false);
 

--- a/webui/src/store/index.js
+++ b/webui/src/store/index.js
@@ -51,6 +51,12 @@ export default new Vuex.Store({
           minMinus12: value => value >= -12 || 'Must be greater than or equal to -12',
           max14: value => value <= 14 || 'Must be less than or equal to 14',
           portRange: value => value > 0 && value <= 65535 || 'Must be between 1 and 65535',
+          noPinDuplicates: value => ((   //dirty code, but creating an array and running a loop seems to be over-engineering
+              this.config.DFPRXpin!=this.config.DFPTXpin && this.config.DFPRXpin!=this.config.BMESDAPin && this.config.DFPRXpin!=this.config.BMESCLPin && this.config.DFPRXpin!=this.config.DHTPin
+           && this.config.DFPTXpin!=this.config.BMESDAPin && this.config.DFPTXpin!=this.config.BMESCLPin && this.config.DFPTXpin!=this.config.DHTPin
+           && this.config.BMESDAPin!=this.config.BMESCLPin && this.config.BMESDAPin!=this.config.DHTPin 
+           //DHT pin and BME-SCL-pin may be identical!
+          ) || 'Pin assignment must be unique'),
     },   
     navLinks: [
         { title: "Dashboard", icon: "mdi-memory", page: "/" },
@@ -110,6 +116,23 @@ export default new Vuex.Store({
     temperatureUnits:  [
         { text: "Celsius °C", value: 0 },
         { text: "Fahrenheit °F", value: 1 },
+    ],
+    ldrDevices:  [
+        { text: "GL5516", value: "GL5516" },
+        { text: "GL5528", value: "GL5528" },
+        { text: "GL5537_1", value: "GL5537_1" },
+        { text: "GL5537_2", value: "GL5537_2" },
+        { text: "GL5539", value: "GL5539" },
+        { text: "GL5549", value: "GL5549" },
+    ],
+    pinsESP8266:  [
+        { text: "Pin D1", value: "Pin_D1" },
+        { text: "Pin D3", value: "Pin_D3" },
+        { text: "Pin D4", value: "Pin_D4" },
+        { text: "Pin D5", value: "Pin_D5" },
+        { text: "Pin D6", value: "Pin_D6" },
+        { text: "Pin D7", value: "Pin_D7" },
+        { text: "Pin D8", value: "Pin_D8" },
     ],
     bmpsFromAPI: [],
     pixelCreatorPixel: {},

--- a/webui/src/store/index.js
+++ b/webui/src/store/index.js
@@ -51,6 +51,7 @@ export default new Vuex.Store({
           minMinus12: value => value >= -12 || 'Must be greater than or equal to -12',
           max14: value => value <= 14 || 'Must be less than or equal to 14',
           portRange: value => value > 0 && value <= 65535 || 'Must be between 1 and 65535',
+          volumeRange: value => value > 0 && value <= 30 || 'Must be between 1 and 30',
           noPinDuplicates: value => ((   //dirty code, but creating an array and running a loop seems to be over-engineering
               this.config.DFPRXpin!=this.config.DFPTXpin && this.config.DFPRXpin!=this.config.BMESDAPin && this.config.DFPRXpin!=this.config.BMESCLPin && this.config.DFPRXpin!=this.config.DHTPin
            && this.config.DFPTXpin!=this.config.BMESDAPin && this.config.DFPTXpin!=this.config.BMESCLPin && this.config.DFPTXpin!=this.config.DHTPin

--- a/webui/src/views/Options.vue
+++ b/webui/src/views/Options.vue
@@ -101,6 +101,7 @@
                         </v-card-title>
                         <hr />
                         <br />
+                        <v-text-field v-model="config.initialVolume" type="number" label="Start volume" hint="Between 1 and 30" :rules="[rules.required, rules.volumeRange]"></v-text-field>
                         <v-select :items="pinsESP8266" v-model="config.DFPRXPin" type="number" label="DFPlayer RX pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
                         <v-select :items="pinsESP8266" v-model="config.DFPTXPin" type="number" label="DFPlayer TX pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
                     </v-card>

--- a/webui/src/views/Options.vue
+++ b/webui/src/views/Options.vue
@@ -28,11 +28,16 @@
                         <hr />
                         <br />
                         <v-select :items="temperatureUnits" v-model="config.temperatureUnit" label="Temperature unit"></v-select>
-                        <v-text-field v-model="config.temperatureOffset" type="number" label="Temperature sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.luxOffset" type="number" label="Lux sensor offset" :rules="[rules.required]"></v-text-field>
+                        <v-select :items="ldrDevices" v-model="config.ldrDevice" type="number" label="Lux sensor type"></v-select>
+                        <v-text-field v-model="config.ldrPulldown" type="number" label="Value of pulldown resistor for LDR" suffix="Ohm" :rules="[rules.required]"></v-text-field>
+                        <v-text-field v-model="config.temperatureOffset" type="number" label="Temperature sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.humidityOffset" type="number" label="Humidity sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.pressureOffset" type="number" label="Pressure sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.gasOffset" type="number" label="Gas sensor offset" :rules="[rules.required]"></v-text-field>
+                        <v-select :items="pinsESP8266" v-model="config.DHTPin" type="number" label="DHT sensor pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
+                        <v-select :items="pinsESP8266" v-model="config.BMESCLPin" type="number" label="BME sensor SCL pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
+                        <v-select :items="pinsESP8266" v-model="config.BMESDAPin" type="number" label="BME sensor SDA pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
                     </v-card>
                 </v-col>
                 <v-col cols="12" lg="3">
@@ -89,6 +94,16 @@
                             </v-col>
                         </v-row>
                     </v-card>
+                    <br/>
+                    <v-card class="pa-2" elevation="4">
+                        <v-card-title>
+                            <h2>Sound</h2>
+                        </v-card-title>
+                        <hr />
+                        <br />
+                        <v-select :items="pinsESP8266" v-model="config.DFPRXPin" type="number" label="DFPlayer RX pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
+                        <v-select :items="pinsESP8266" v-model="config.DFPTXPin" type="number" label="DFPlayer TX pin (ESP8266 only)" :rules="[rules.noPinDuplicates]" :visible="!config.isESP8266"></v-select>
+                    </v-card>
                 </v-col>
                 <v-col cols="12" lg="3">
                     <v-card class="pa-1" elevation="4">
@@ -142,6 +157,12 @@ export default {
         },
         temperatureUnits() {
             return this.$store.state.temperatureUnits;
+        },
+        ldrDevices() {
+            return this.$store.state.ldrDevices;
+        },
+        pinsESP8266() {
+            return this.$store.state.pinsESP8266;
         },
     },
     methods: {


### PR DESCRIPTION
* (ESP8266 only) The pins for sensors can be chosen in the options and will be stored in the configuration file.
* LDR type and pulldown resistor value can be set in the options.
* MP3Player sometimes cannot handle two commands in a row ("volume", then "play"). Insert delay if there's a second command.
Partially resolves #79 and #17 .