### PR TITLE
Add ZigZagWipe, bitmapWipe and randomization for wipes

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -887,6 +887,7 @@ void CreateFrames(JsonObject &json)
 		bool fadeAnimationAktiv = false;
 		bool coloredBarWipeAnimationAktiv = false;
 		bool zigzagWipeAnimationAktiv = false;
+		bool bitmapWipeAnimationAktiv = false;
 		if (json.containsKey("switchAnimation"))
 		{
 			logMessage += F("SwitchAnimation, ");
@@ -906,6 +907,10 @@ void CreateFrames(JsonObject &json)
 				{
 					zigzagWipeAnimationAktiv = true;
 				}
+				else if (json["switchAnimation"]["animation"] == "bitmapWipe")
+				{
+					bitmapWipeAnimationAktiv = true;
+				}		
 			}
 		}
 
@@ -935,7 +940,11 @@ void CreateFrames(JsonObject &json)
 			}
 			ZigZagWipe(r,g,b);
 		}
-
+		else if (bitmapWipeAnimationAktiv)
+		{
+			BitmapWipe(json["switchAnimation"]["data"].as<JsonArray>(),json["switchAnimation"]["w"].as<uint8_t>());
+		}
+		
 		// Clock
 		if (json.containsKey("clock"))
 		{
@@ -1141,7 +1150,7 @@ void CreateFrames(JsonObject &json)
 		}
 
 		// Fade aktiv?
-		if (!scrollTextAktiv && (fadeAnimationAktiv || coloredBarWipeAnimationAktiv || zigzagWipeAnimationAktiv))
+		if (!scrollTextAktiv && (fadeAnimationAktiv || coloredBarWipeAnimationAktiv || zigzagWipeAnimationAktiv || bitmapWipeAnimationAktiv))
 		{
 			FadeIn();
 		}
@@ -1803,6 +1812,24 @@ void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
 	}
 	matrix->fillRect(0, 0, 32, 8, matrix->Color(0, 0, 0));
 	matrix->show();
+}
+
+void BitmapWipe(JsonArray &data, int16_t w)
+{
+	for (int16_t x = -w+1; x <=31; x++)
+	{
+		int16_t y = 0;
+		for (int16_t j = 0; j < 8; j++, y++)
+		{
+			for (int16_t i = 0; i < w; i++)
+			{
+				matrix->drawPixel(x + i, y, data[j * w + i].as<uint16_t>());
+			}
+		}
+	matrix->show();
+	delay(18);
+	matrix->fillRect(0,0,x,8, matrix->Color(0, 0, 0));
+	}
 }
 
 void ColorFlash(int red, int green, int blue)

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -911,6 +911,20 @@ void CreateFrames(JsonObject &json)
 				{
 					bitmapWipeAnimationAktiv = true;
 				}		
+				else if (json["switchAnimation"]["animation"] == "random")
+				{
+					switch(millis()%3){
+						case 0:
+							fadeAnimationAktiv = true;
+							break;
+						case 1:
+							coloredBarWipeAnimationAktiv = true;
+							break;
+						case 2:
+							zigzagWipeAnimationAktiv = true;
+							break;
+					}
+				}		
 			}
 		}
 

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -886,6 +886,7 @@ void CreateFrames(JsonObject &json)
 		// Ist eine Switch Animation übergeben worden?
 		bool fadeAnimationAktiv = false;
 		bool coloredBarWipeAnimationAktiv = false;
+		bool zigzagWipeAnimationAktiv = false;
 		if (json.containsKey("switchAnimation"))
 		{
 			logMessage += F("SwitchAnimation, ");
@@ -901,6 +902,10 @@ void CreateFrames(JsonObject &json)
 				{
 					coloredBarWipeAnimationAktiv = true;
 				}
+				else if (json["switchAnimation"]["animation"] == "zigzagWipe")
+				{
+					zigzagWipeAnimationAktiv = true;
+				}
 			}
 		}
 
@@ -912,6 +917,23 @@ void CreateFrames(JsonObject &json)
 		else if (coloredBarWipeAnimationAktiv)
 		{
 			ColoredBarWipe();
+		}
+		else if (zigzagWipeAnimationAktiv)
+		{
+			uint8_t r=255;
+			uint8_t g=255;
+			uint8_t b=255;
+			if (json["switchAnimation"]["hexColor"].as<char *>() != NULL)
+			{
+				ColorConverter::HexToRgb(json["text"]["hexColor"].as<char *>(), r, g, b);
+			}
+			else
+			{
+				r = json["switchAnimation"]["color"]["r"].as<uint8_t>();
+				g = json["switchAnimation"]["color"]["g"].as<uint8_t>();
+				b = json["switchAnimation"]["color"]["b"].as<uint8_t>();
+			}
+			ZigZagWipe(r,g,b);
 		}
 
 		// Clock
@@ -1119,7 +1141,7 @@ void CreateFrames(JsonObject &json)
 		}
 
 		// Fade aktiv?
-		if (!scrollTextAktiv && (fadeAnimationAktiv || coloredBarWipeAnimationAktiv))
+		if (!scrollTextAktiv && (fadeAnimationAktiv || coloredBarWipeAnimationAktiv || zigzagWipeAnimationAktiv))
 		{
 			FadeIn();
 		}
@@ -1741,6 +1763,46 @@ void ColoredBarWipe()
 		matrix->show();
 		delay(15);
 	}
+}
+
+void ZigZagWipe(uint8_t r, uint8_t g, uint8_t b)
+{
+	for (uint16_t row = 0; row <=7; row+=2)
+	{
+		for (uint16_t col = 0; col <= 31; col++)
+		{
+			if (row==0 || row==4)
+			{
+				matrix->fillRect(0, row, col - 1, 2, matrix->Color(0, 0, 0));
+				matrix->drawFastVLine(col-1, row, 2, matrix->Color(r,g,b));
+				matrix->drawFastVLine(col, row, 2, matrix->Color(r,g,b));
+			}
+			else
+			{
+				matrix->fillRect(32-col, row,col, 2, matrix->Color(0, 0, 0));
+				matrix->drawFastVLine(32-col, row, 2, matrix->Color(r,g,b));
+				matrix->drawFastVLine(32-col-1, row, 2, matrix->Color(r,g,b));
+			}
+			matrix->show();
+			delay(5);
+		}
+		matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
+		if (row==0 || row==4)
+		{
+				matrix->drawFastVLine(30, row+1, 2, matrix->Color(r,g,b));
+				matrix->drawFastVLine(31, row+1, 2, matrix->Color(r,g,b));
+		}
+		else
+		{
+			matrix->drawFastVLine(0, row+1, 2, matrix->Color(r,g,b));
+			matrix->drawFastVLine(1, row+1, 2, matrix->Color(r,g,b));
+		}
+		matrix->show();
+		delay(5);
+		matrix->fillRect(0, row, 32, 2, matrix->Color(0, 0, 0));
+	}
+	matrix->fillRect(0, 0, 32, 8, matrix->Color(0, 0, 0));
+	matrix->show();
 }
 
 void ColorFlash(int red, int green, int blue)

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -925,9 +925,9 @@ void CreateFrames(JsonObject &json)
 			uint8_t b=255;
 			if (json["switchAnimation"]["hexColor"].as<char *>() != NULL)
 			{
-				ColorConverter::HexToRgb(json["text"]["hexColor"].as<char *>(), r, g, b);
+				ColorConverter::HexToRgb(json["switchAnimation"]["hexColor"].as<char *>(), r, g, b);
 			}
-			else
+			else if (json["switchAnimation"]["color"]["r"].as<char *>() != NULL)
 			{
 				r = json["switchAnimation"]["color"]["r"].as<uint8_t>();
 				g = json["switchAnimation"]["color"]["g"].as<uint8_t>();

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -942,7 +942,7 @@ void CreateFrames(JsonObject &json)
 		}
 		else if (bitmapWipeAnimationAktiv)
 		{
-			BitmapWipe(json["switchAnimation"]["data"].as<JsonArray>(),json["switchAnimation"]["w"].as<uint8_t>());
+			BitmapWipe(json["switchAnimation"]["data"].as<JsonArray>(),json["switchAnimation"]["width"].as<uint8_t>());
 		}
 		
 		// Clock


### PR DESCRIPTION
Create new switchAnimation effect "zigzagWipe". Takes color as optional parameter.

Create new switchAnimation effect "bitmapWip". Allows to have a bitmap eat the old display.
The bitmap must not be animated, it must have height=8. Width can be anything between 1 and 32.
New parameters to switchAnimation:
"animation": "bitmapWipe",
"data": [your bitmap],
"w":8 //or any other width of your bitmap