### PR TITLE
Bugfix: show "HOTSPOT" in display

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -245,7 +245,10 @@ void SetCurrentMatrixBrightness(float newBrightness)
 
 void EnteredHotspotCallback(WiFiManager *manager)
 {
+	Log(F("Hotspot"),"Waiting for WiFi configuration");
+	matrix->clear();
 	DrawTextHelper("HOTSPOT", false, false, false, false, false, false, NULL, 255, 255, 255, 3, 1);
+	FadeIn();
 }
 
 void SaveConfig()


### PR DESCRIPTION
PixelIt was intended to display "HOTSPOT" while in AP mode during WiFi setup. However, text was not displayed properly.