### PR TITLE
Added support for BH1750 light sensor

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,7 @@ lib_deps =
 	WiFiManager = https://github.com/tzapu/WiFiManager.git#esp32s2
 	plerup/EspSoftwareSerial@^6.11.4
 	adafruit/Adafruit BME680 Library@^2.0.1
+	claws/BH1750@^1.2.0
 
 [env:ESP8266]
 platform = espressif8266@2.6.3
@@ -55,6 +56,7 @@ lib_deps =
 	${common.lib_deps}
 	tzapu/WiFiManager@^0.16.0
 	adafruit/Adafruit BME680 Library@^2.0.1
+	claws/BH1750@^1.2.0
 
 [env:d1_mini]
 platform = espressif8266@2.6.3
@@ -67,3 +69,4 @@ lib_deps =
 	${common.lib_deps}
 	tzapu/WiFiManager@^0.16.0
 	adafruit/Adafruit BME680 Library@^2.0.1
+	claws/BH1750@^1.2.0

--- a/webui/src/views/Options.vue
+++ b/webui/src/views/Options.vue
@@ -29,15 +29,15 @@
                         <br />
                         <v-select :items="temperatureUnits" v-model="config.temperatureUnit" label="Temperature unit"></v-select>
                         <v-text-field v-model="config.luxOffset" type="number" label="Lux sensor offset" :rules="[rules.required]"></v-text-field>
-                        <v-select :items="ldrDevices" v-model="config.ldrDevice" type="number" label="Lux sensor type"></v-select>
-                        <v-text-field v-model="config.ldrPulldown" type="number" label="Value of pulldown resistor for LDR" suffix="Ohm" :rules="[rules.required]"></v-text-field>
+                        <v-select :items="ldrDevices" v-model="config.ldrDevice" type="number" label="Lux sensor type" hint="Pick any value when using BH1750"></v-select>
+                        <v-text-field v-model="config.ldrPulldown" type="number" label="Value of pulldown resistor for LDR" suffix="Ohm" hint="Enter any value when using BH1750" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.temperatureOffset" type="number" label="Temperature sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.humidityOffset" type="number" label="Humidity sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.pressureOffset" type="number" label="Pressure sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.gasOffset" type="number" label="Gas sensor offset" :rules="[rules.required]"></v-text-field>
-                        <v-select :items="pinsESP8266" v-model="config.DHTPin" type="number" label="DHT sensor pin (ESP8266 only)" :disabled="!config.isESP8266"></v-select>
-                        <v-select :items="pinsESP8266" v-model="config.BMESCLPin" type="number" label="BME sensor SCL pin (ESP8266 only)" :disabled="!config.isESP8266"></v-select>
-                        <v-select :items="pinsESP8266" v-model="config.BMESDAPin" type="number" label="BME sensor SDA pin (ESP8266 only)" :disabled="!config.isESP8266"></v-select>
+                        <v-select :items="pinsESP8266" v-model="config.onewirePin" type="number" label="DHT sensor pin (ESP8266 only)" :disabled="!config.isESP8266"></v-select>
+                        <v-select :items="pinsESP8266" v-model="config.SCLPin" type="number" label="Temperature/Lux sensor SCL pin (ESP8266 only)" :disabled="!config.isESP8266"></v-select>
+                        <v-select :items="pinsESP8266" v-model="config.SDAPin" type="number" label="Temperature/Lux sensor SDA pin (ESP8266 only)" :disabled="!config.isESP8266"></v-select>
                     </v-card>
                 </v-col>
                 <v-col cols="12" lg="3">


### PR DESCRIPTION
Support for BH1750 light sensor has been added. Only address 0x23 will be supported (pin ADDR=OPEN).

BH1750 requires SDA/SCL pins. You can use BME280 or BME680 in parallel. If you want to combine it with DHT22, you need to select different pins for 1Wire (used by DHT22) and I2C (used by BME280, BME680 and BH1750) on the Options page.

BREAKING CHANGE: changed names of pin assignments in configruration. If you used non-default pins, you have to redo your pin assignment.