### PR TITLE
Fix BitmapWipe

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -1989,6 +1989,7 @@ void BitmapWipe(JsonArray &data, int16_t w)
 		matrix->show();
 		delay(18);
 		matrix->fillRect(0, 0, x, 8, matrix->Color(0, 0, 0));
+		matrix->show();
 	}
 }
 


### PR DESCRIPTION
Sometimes, the sprite appears once more before the next screen comes up