### PR TITLE
LDR smoothing

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -83,11 +83,12 @@ String SCLPin = "Pin_D1";
 String SDAPin = "Pin_D3";
 String ldrDevice = "GL5516";
 unsigned long ldrPulldown = 10000; // 10k pulldown-resistor
+unsigned int ldrSmoothing = 0;
 
 #define NUMMATRIX (32 * 8)
 CRGB leds[NUMMATRIX];
 
-#define VERSION "0.3.15pinconfig_BH1750"
+#define VERSION "0.3.15pinconfig_ldrSmooth"
 
 #if defined(ESP8266)
 bool isESP8266 = true;
@@ -319,6 +320,7 @@ void SaveConfig()
 		json["SDAPin"] = SDAPin;
 		json["ldrDevice"] = ldrDevice;
 		json["ldrPulldown"] = ldrPulldown;
+		json["ldrSmoothing"] = ldrSmoothing;
 
 		json["initialVolume"] = initialVolume;
 
@@ -591,6 +593,12 @@ void SetConfigVaribles(JsonObject &json)
 	{
 		ldrPulldown = json["ldrPulldown"].as<unsigned long>();
 	}
+
+	if (json.containsKey("ldrSmoothing"))
+	{
+		ldrSmoothing = json["ldrSmoothing"].as<uint>();
+	}
+
 	if (json.containsKey("initialVolume"))
 	{
 		initialVolume = json["initialVolume"].as<uint>();
@@ -2293,7 +2301,7 @@ void setup()
 	}
 	else
 	{
-		photocell = new LightDependentResistor(LDR_PIN, ldrPulldown, TranslatePhotocell(ldrDevice), 10);
+		photocell = new LightDependentResistor(LDR_PIN, ldrPulldown, TranslatePhotocell(ldrDevice), 10, ldrSmoothing);
 		photocell->setPhotocellPositionOnGround(false);
 		luxSensor = LuxSensor_LDR;
 	}
@@ -2546,7 +2554,7 @@ void loop()
 		}
 		else
 		{
-			currentLux = (roundf(photocell->getCurrentLux() * 1000) / 1000) + luxOffset;
+			currentLux = (roundf(photocell->getSmoothedLux() * 1000) / 1000) + luxOffset;
 		}
 
 		SendLDR(false);

--- a/webui/src/views/Options.vue
+++ b/webui/src/views/Options.vue
@@ -31,6 +31,7 @@
                         <v-text-field v-model="config.luxOffset" type="number" label="Lux sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-select :items="ldrDevices" v-model="config.ldrDevice" type="number" label="Lux sensor type" hint="Pick any value when using BH1750"></v-select>
                         <v-text-field v-model="config.ldrPulldown" type="number" label="Value of pulldown resistor for LDR" suffix="Ohm" hint="Enter any value when using BH1750" :rules="[rules.required]"></v-text-field>
+                        <v-text-field v-model="config.ldrSmoothing" type="number" label="Number of historic LDR readings to be used for linear smoothing (LDR only)" hint="Enter any value when using BH1750" :rules="[rules.required, rules.min0]"></v-text-field>
                         <v-text-field v-model="config.temperatureOffset" type="number" label="Temperature sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.humidityOffset" type="number" label="Humidity sensor offset" :rules="[rules.required]"></v-text-field>
                         <v-text-field v-model="config.pressureOffset" type="number" label="Pressure sensor offset" :rules="[rules.required]"></v-text-field>


### PR DESCRIPTION
Linear smoothing of LDR values can help if LDR readings are unstable.

On the Options page, the number of historic values to be used for smoothing can be specified.
E.g. "30" means: "perform linear smoothing over the last 30 LDR readings and take the linear average".
"0" means: "take current reading from LDR"