### PR TITLE
UNDER CONSTRUCTION: Fix MP3 Problems

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -110,7 +110,7 @@ btnActions btnAction[] = {btnAction_ToggleSleepMode, btnAction_GotoClock, btnAct
 #define NUMMATRIX (32 * 8)
 CRGB leds[NUMMATRIX];
 
-#define VERSION "0.3.16_beta"
+#define VERSION "0.3.16_beta_mp3delay"
 
 #if defined(ESP8266)
 bool isESP8266 = true;
@@ -1022,11 +1022,40 @@ void CreateFrames(JsonObject &json)
 		{
 			if (json["sound"]["folder"])
 			{
-				mp3Player.playFolder(json["sound"]["folder"].as<int>(), json["sound"]["file"].as<int>());
+				if (json["sound"]["quick"])
+				{
+					mp3Player.playFolder(json["sound"]["folder"].as<int>(), json["sound"]["file"].as<int>());
+				}
+				else
+				{
+					uint attempt=0;
+					do
+					{
+						attempt++;
+						Log(F("Sound"), "Attempt: "+String(attempt)+" "+String(millis()));
+						mp3Player.playFolder(json["sound"]["folder"].as<int>(), json["sound"]["file"].as<int>());
+						delay(100+attempt*100);
+					}
+					while (attempt <5 && !mp3Player.isPlaying());
+				}
 			}
 			else
 			{
-				mp3Player.play(json["sound"]["file"].as<int>());
+				if (json["sound"]["quick"])
+				{
+					mp3Player.play(json["sound"]["file"].as<int>());
+				}
+				else
+				{
+					uint attempt=0;
+					do
+					{
+						attempt++;
+						Log(F("Sound"), "Attempt: "+String(attempt)+" "+String(millis()));
+						mp3Player.play(json["sound"]["file"].as<int>());
+						delay(100+attempt*100);
+					} while (attempt <5 && !mp3Player.isPlaying());
+				}
 			}
 		}
 		// Stop


### PR DESCRIPTION
Randomly sometimes DFPlayer does not play an MP3 file, although the very next command will be followed without any problems.
See https://reprage.com/post/dfplayer-mini-cheat-sheet for a matching description of the problem.

The author there suggests to try playing the file until the DFPlayer actually is playing the file.

This is what I attempted here. However, this includes some delay() commands, which becomes very obvious if you are sending MP3 commands while text is scrolling. Therefore I introduced a "quick" option which doesn't re-attempt to start playing.

What do you think? Is this option useful?
I do not know how the DFPlayer responds to command slike pause, next etc., i.e. I do not know if there reliability issues as well.