### PR TITLE
Increase interval between reconnect attempts; correct LWT

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -63,7 +63,7 @@ String mqttServer = "";
 String mqttMasterTopic = "Haus/PixelIt/";
 int mqttPort = 1883;
 unsigned long mqttLastReconnectAttempt = 0; // will store last time reconnect to mqtt broker
-const int MQTT_RECONNECT_INTERVAL = 5000;
+const int MQTT_RECONNECT_INTERVAL = 15000;
 //#define MQTT_MAX_PACKET_SIZE 8000
 
 //// LDR Config
@@ -2005,12 +2005,12 @@ boolean MQTTreconnect()
 	if (mqttUser != NULL && mqttUser.length() > 0 && mqttPassword != NULL && mqttPassword.length() > 0)
 	{
 		Log(F("MQTTreconnect"), F("MQTT connecting to broker with user and password"));
-		connected = client.connect(hostname.c_str(), mqttUser.c_str(), mqttPassword.c_str(), "state", 0, true, "diconnected");
+		connected = client.connect(hostname.c_str(), mqttUser.c_str(), mqttPassword.c_str(), (mqttMasterTopic + "state").c_str(), 0, true, "disconnected");
 	}
 	else
 	{
 		Log(F("MQTTreconnect"), F("MQTT connecting to broker without user and password"));
-		connected = client.connect(hostname.c_str(), "state", 0, true, "diconnected");
+		connected = client.connect(hostname.c_str(), (mqttMasterTopic + "state").c_str(), 0, true, "disconnected");
 	}
 
 	// Attempt to connect


### PR DESCRIPTION
In my experience, a connection attempt to a non-existant broker needs about 5 seconds before timing out. With a reconnect invertal of 5 seconds, the next connection attempt will follow immediately.
As the attempt is blocking, API will not respond during the attempts. In other words: you can't disable MQTT if the broker is failing, because there is no chance to open the WebUI.

Corrected a typo in the Last Will message and corrected the topic for the Last Will message (shouldn't be a global state).