### PR TITLE
Time format suggestions

### DIFF
--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -232,6 +232,7 @@ uint8_t clockColorR = 255, clockColorG = 255, clockColorB = 255;
 uint clockAutoFallbackTime = 30;
 bool forceClock = false;
 bool clockBlinkAnimated = true;
+bool clockShowAMPM = true;
 
 // Scrolltext Vars
 bool scrollTextAktivLoop = false;
@@ -328,6 +329,7 @@ void SaveConfig()
 	json["clockDateDayMonth"] = clockDateDayMonth;
 	json["clockDayOfWeekFirstMonday"] = clockDayOfWeekFirstMonday;
 	json["clockBlinkAnimated"] = clockBlinkAnimated;
+	json["clockShowAMPM"] = clockShowAMPM;
 	json["scrollTextDefaultDelay"] = scrollTextDefaultDelay;
 	json["bootScreenAktiv"] = bootScreenAktiv;
 	json["mqttAktiv"] = mqttAktiv;
@@ -525,6 +527,11 @@ void SetConfigVariables(JsonObject &json)
 	if (json.containsKey("clockBlinkAnimated"))
 	{
 		clockBlinkAnimated = json["clockBlinkAnimated"].as<bool>();
+	}
+
+	if (json.containsKey("clockShowAMPM"))
+	{
+		clockShowAMPM = json["clockShowAMPM"].as<bool>();
 	}
 
 	if (json.containsKey("clockAutoFallbackActive"))
@@ -1221,6 +1228,7 @@ void CreateFrames(JsonObject &json)
 
 				clockWithSeconds = json["clock"]["withSeconds"];
 				clockBlinkAnimated = json["clock"]["blinkAnimated"];
+				clockShowAMPM = json["clock"]["showAMPM"];
 
 				if (json["clock"]["color"]["r"].as<char *>() != NULL)
 				{
@@ -1942,12 +1950,12 @@ void DrawClock(bool fromJSON)
 		if (clockBlink && clockBlinkAnimated)
 		{
 			clockBlink = false;
-			sprintf_P(time, PSTR("%02d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%2d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 		else
 		{
 			clockBlink = !clockBlink;
-			sprintf_P(time, PSTR("%02d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%2d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 	}
 	else

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -231,6 +231,7 @@ time_t clockLastUpdate;
 uint8_t clockColorR = 255, clockColorG = 255, clockColorB = 255;
 uint clockAutoFallbackTime = 30;
 bool forceClock = false;
+bool clockBlinkAnimated = true;
 
 // Scrolltext Vars
 bool scrollTextAktivLoop = false;
@@ -326,6 +327,7 @@ void SaveConfig()
 	json["clockAutoFallbackAnimation"] = clockAutoFallbackAnimation;
 	json["clockDateDayMonth"] = clockDateDayMonth;
 	json["clockDayOfWeekFirstMonday"] = clockDayOfWeekFirstMonday;
+	json["clockBlinkAnimated"] = clockBlinkAnimated;
 	json["scrollTextDefaultDelay"] = scrollTextDefaultDelay;
 	json["bootScreenAktiv"] = bootScreenAktiv;
 	json["mqttAktiv"] = mqttAktiv;
@@ -518,6 +520,11 @@ void SetConfigVariables(JsonObject &json)
 	if (json.containsKey("clockWithSeconds"))
 	{
 		clockWithSeconds = json["clockWithSeconds"].as<bool>();
+	}
+
+	if (json.containsKey("clockBlinkAnimated"))
+	{
+		clockBlinkAnimated = json["clockBlinkAnimated"].as<bool>();
 	}
 
 	if (json.containsKey("clockAutoFallbackActive"))
@@ -1213,6 +1220,7 @@ void CreateFrames(JsonObject &json)
 				}
 
 				clockWithSeconds = json["clock"]["withSeconds"];
+				clockBlinkAnimated = json["clock"]["blinkAnimated"];
 
 				if (json["clock"]["color"]["r"].as<char *>() != NULL)
 				{
@@ -1931,30 +1939,30 @@ void DrawClock(bool fromJSON)
 	{
 		xPosTime = 2;
 
-		if (clockBlink)
+		if (clockBlink && clockBlinkAnimated)
 		{
 			clockBlink = false;
-			sprintf_P(time, PSTR("%02d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%02d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 		else
 		{
 			clockBlink = !clockBlink;
-			sprintf_P(time, PSTR("%02d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%02d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 	}
 	else
 	{
 		xPosTime = 7;
 
-		if (clockBlink)
+		if (clockBlink && clockBlinkAnimated)
 		{
 			clockBlink = false;
-			sprintf_P(time, PSTR("%02d:%02d"), hour(), minute());
+			sprintf_P(time, PSTR("%02d %02d"), hour(), minute());
 		}
 		else
 		{
 			clockBlink = !clockBlink;
-			sprintf_P(time, PSTR("%02d %02d"), hour(), minute());
+			sprintf_P(time, PSTR("%02d:%02d"), hour(), minute());
 		}
 	}
 

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -232,7 +232,6 @@ uint8_t clockColorR = 255, clockColorG = 255, clockColorB = 255;
 uint clockAutoFallbackTime = 30;
 bool forceClock = false;
 bool clockBlinkAnimated = true;
-bool clockShowAMPM = true;
 
 // Scrolltext Vars
 bool scrollTextAktivLoop = false;
@@ -329,7 +328,6 @@ void SaveConfig()
 	json["clockDateDayMonth"] = clockDateDayMonth;
 	json["clockDayOfWeekFirstMonday"] = clockDayOfWeekFirstMonday;
 	json["clockBlinkAnimated"] = clockBlinkAnimated;
-	json["clockShowAMPM"] = clockShowAMPM;
 	json["scrollTextDefaultDelay"] = scrollTextDefaultDelay;
 	json["bootScreenAktiv"] = bootScreenAktiv;
 	json["mqttAktiv"] = mqttAktiv;
@@ -527,11 +525,6 @@ void SetConfigVariables(JsonObject &json)
 	if (json.containsKey("clockBlinkAnimated"))
 	{
 		clockBlinkAnimated = json["clockBlinkAnimated"].as<bool>();
-	}
-
-	if (json.containsKey("clockShowAMPM"))
-	{
-		clockShowAMPM = json["clockShowAMPM"].as<bool>();
 	}
 
 	if (json.containsKey("clockAutoFallbackActive"))
@@ -1228,7 +1221,6 @@ void CreateFrames(JsonObject &json)
 
 				clockWithSeconds = json["clock"]["withSeconds"];
 				clockBlinkAnimated = json["clock"]["blinkAnimated"];
-				clockShowAMPM = json["clock"]["showAMPM"];
 
 				if (json["clock"]["color"]["r"].as<char *>() != NULL)
 				{
@@ -1950,12 +1942,12 @@ void DrawClock(bool fromJSON)
 		if (clockBlink && clockBlinkAnimated)
 		{
 			clockBlink = false;
-			sprintf_P(time, PSTR("%2d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%02d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 		else
 		{
 			clockBlink = !clockBlink;
-			sprintf_P(time, PSTR("%2d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%02d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 	}
 	else

--- a/src/PixelIt.ino
+++ b/src/PixelIt.ino
@@ -1942,12 +1942,12 @@ void DrawClock(bool fromJSON)
 		if (clockBlink && clockBlinkAnimated)
 		{
 			clockBlink = false;
-			sprintf_P(time, PSTR("%02d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%2d %02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 		else
 		{
 			clockBlink = !clockBlink;
-			sprintf_P(time, PSTR("%02d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
+			sprintf_P(time, PSTR("%2d:%02d %s"), hourFormat12(), minute(), isAM() ? "AM" : "PM");
 		}
 	}
 	else


### PR DESCRIPTION
Hello, I'm suggesting two changes to this repo:

1. Remove the leading zero from 12h time format. It's customary to drop the leading zero when displaying 12h clock and the leading zero is sometimes used as a hint that the time is 24h format, especially because _some_ clocks omit the AM/PM indicator (i.e. reading 08:00 means it's definitely 8 in the morning, but reading 8:00 on a microwave means it's one of the two 8 o'clocks). Sources: https://en.wikipedia.org/wiki/12-hour_clock, and also https://www.worlddata.info/timezones/date-time-notation.php _("At all hours from 1-9, the recognition is even a bit easier, because in order to stand out from the 24-hour format also optically, leading zeros are left out. The time "17:30" then becomes an easily distinguishable "5:30 pm".")_

2. Provide option for non-flashing time separator. My personal view is that on a large, ambient display clock a blinking separator is annoying. I'm sure others will disagree so having an option seems sensible. However this change isn't quite complete - it works from the REST API ("clockBlinkAnimated") but it is not supported from the web interface. I just couldn't work out the web interface bit - it seems like it has to be changed on github and then the new URL used in the clock code? I'm afraid I don't know Vue at all either.